### PR TITLE
Initialize personal toolkit with web scraping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Target website to scrape
+SCRAPER_TARGET_URL=https://example.com
+
+# Optional: override cron schedule in vercel.json if managing externally
+SCRAPER_CRON_SCHEDULE=0 * * * *
+
+# Optional webhook notified on success
+WEBHOOK_URL=
+
+# Vercel KV (enable in Vercel Integrations)
+KV_REST_API_URL=
+KV_REST_API_TOKEN=
+KV_REST_API_READ_ONLY_TOKEN=
+KV_URL=
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.next
+.vercel
+node_modules
+*.log
+.env
+pnpm-lock.yaml
+yarn.lock
+package-lock.json
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# 个人工具箱合集
+# 个人工具箱 (Vercel 一键部署)
+
+本仓库是一个可在 Vercel 免费版上运行的个人工具集合。已内置：
+
+- 定时抓取器：按计划抓取网页内容，保存到 Vercel KV，并在成功时调用 Webhook。
+- 首页工具索引：自动展示所有工具入口。
+
+## 一键部署
+
+1. Fork 或导入本仓库到你的 Git 平台
+2. 在 Vercel 导入项目，框架选择 Next.js，Node 18+
+3. 在 Vercel → Integrations 启用 Vercel KV，并把以下环境变量填好：
+   - SCRAPER_TARGET_URL
+   - WEBHOOK_URL (可选)
+4. 部署后，Vercel 会根据 `vercel.json` 的 `crons` 每小时调用 `/api/tools/scraper/run`
+
+## 本地开发
+
+```bash
+pnpm i # 或 npm i / yarn
+pnpm dev
+```
+
+## 环境变量
+
+参见 `.env.example`。
+
+## 目录结构
+
+- `src/app` 应用入口、页面与 API Routes
+- `src/lib` 通用库（env、kv、scraper、tools 列表）
+
+## API
+
+- `GET /api/tools/scraper/run` 触发一次抓取并写入 KV，成功时发 Webhook
+- `GET /api/tools/scraper/records` 获取最近记录
+
+## 自定义与扩展
+
+- 在 `src/lib/tools.ts` 中注册新的工具项
+- 在 `src/app/tools/<your-tool>/page.tsx` 中实现你的工具 UI
+- 若需要更多计划任务，可在 `vercel.json` 中添加 `crons` 项

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "personal-toolbox",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@vercel/kv": "^2.0.0",
+    "cheerio": "^1.0.0",
+    "next": "^14.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
+    "typescript": "^5.5.4"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}
+

--- a/src/app/api/tools/scraper/records/route.ts
+++ b/src/app/api/tools/scraper/records/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getRecentScrapeRecords } from '@/lib/kv';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const list = await getRecentScrapeRecords(50);
+  return NextResponse.json({ ok: true, list });
+}
+

--- a/src/app/api/tools/scraper/run/route.ts
+++ b/src/app/api/tools/scraper/run/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { runScrapeOnce } from '@/lib/scraper';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  try {
+    const rec = await runScrapeOnce();
+    return NextResponse.json({ ok: true, record: rec });
+  } catch (err: unknown) {
+    return NextResponse.json({ ok: false, error: (err as Error).message }, { status: 500 });
+  }
+}
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,11 @@
+:root{--fg:#111;--bg:#fff;--muted:#666;--brand:#0ea5e9;--card:#fafafa;border-color:#e5e7eb}
+*{box-sizing:border-box}
+html,body{padding:0;margin:0;color:var(--fg);background:var(--bg);font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,Apple Color Emoji,Segoe UI Emoji}
+a{color:var(--brand);text-decoration:none}
+header{display:flex;justify-content:space-between;align-items:center;margin-bottom:24px}
+.card{border:1px solid var(--card);background:#fff;border-radius:12px;padding:16px}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:16px}
+.muted{color:var(--muted)}
+button{background:var(--brand);color:#fff;border:none;border-radius:8px;padding:10px 14px;cursor:pointer}
+button[disabled]{opacity:.6;cursor:not-allowed}
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: '我的工具箱 | Toolbox',
+  description: '个人工具箱合集，一键部署到 Vercel',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="zh-CN">
+      <body>
+        <main style={{ maxWidth: 960, margin: '0 auto', padding: '24px' }}>
+          {children}
+        </main>
+      </body>
+    </html>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+import { allTools } from '@/lib/tools';
+
+export default function HomePage() {
+  return (
+    <div>
+      <header>
+        <h1>我的工具箱</h1>
+        <span className="muted">一键部署到 Vercel · 免费版可用能力封装</span>
+      </header>
+
+      <div className="grid">
+        {allTools.map(tool => (
+          <div key={tool.slug} className="card">
+            <h3 style={{ marginTop: 0 }}>{tool.title}</h3>
+            <p className="muted" style={{ minHeight: 44 }}>{tool.description}</p>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <Link href={tool.href}><button>打开</button></Link>
+              {tool.docsHref && (
+                <a href={tool.docsHref} target="_blank" rel="noreferrer" className="muted">文档</a>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/tools/scraper/page.tsx
+++ b/src/app/tools/scraper/page.tsx
@@ -1,0 +1,29 @@
+import { getRecentScrapeRecords } from '@/lib/kv';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ScraperPage() {
+  const records = await getRecentScrapeRecords(20);
+  return (
+    <div>
+      <h2>定时抓取器</h2>
+      <p className="muted">展示最近抓取的记录。可在 Vercel 上配置 Cron 触发。</p>
+      <div style={{ display: 'flex', gap: 8, margin: '12px 0' }}>
+        <a href="/api/tools/scraper/run" target="_blank" rel="noreferrer"><button>手动触发一次</button></a>
+        <a href="/api/tools/scraper/records" target="_blank" rel="noreferrer" className="muted">查看 JSON</a>
+      </div>
+      <div className="grid">
+        {records.map((r) => (
+          <div key={r.id} className="card">
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <strong>{new Date(r.createdAt).toLocaleString()}</strong>
+              <span className="muted">{r.ok ? '成功' : '失败'} · {r.status}</span>
+            </div>
+            <div style={{ marginTop: 8, whiteSpace: 'pre-wrap' }}>{r.extractedText || '(无内容)'}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,14 @@
+export const env = {
+  SCRAPER_TARGET_URL: process.env.SCRAPER_TARGET_URL ?? '',
+  SCRAPER_CRON_SCHEDULE: process.env.SCRAPER_CRON_SCHEDULE ?? '0 * * * *',
+  WEBHOOK_URL: process.env.WEBHOOK_URL ?? '',
+  KV_REST_API_URL: process.env.KV_REST_API_URL ?? '',
+  KV_REST_API_TOKEN: process.env.KV_REST_API_TOKEN ?? '',
+  KV_REST_API_READ_ONLY_TOKEN: process.env.KV_REST_API_READ_ONLY_TOKEN ?? '',
+  KV_URL: process.env.KV_URL ?? ''
+};
+
+export function assertRequiredEnv() {
+  if (!env.SCRAPER_TARGET_URL) throw new Error('Missing SCRAPER_TARGET_URL');
+}
+

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -1,0 +1,34 @@
+import { kv } from '@vercel/kv';
+
+const isKvConfigured = Boolean(process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN);
+
+export type ScrapeRecord = {
+  id: string; // timestamp id
+  ok: boolean;
+  url: string;
+  status: number;
+  extractedText: string;
+  createdAt: string; // ISO
+};
+
+const SCRAPE_LIST_KEY = 'scraper:records';
+const memoryStore: ScrapeRecord[] = [];
+
+export async function addScrapeRecord(record: ScrapeRecord): Promise<void> {
+  if (!isKvConfigured) {
+    memoryStore.unshift(record);
+    if (memoryStore.length > 200) memoryStore.length = 200;
+    return;
+  }
+  await kv.lpush(SCRAPE_LIST_KEY, JSON.stringify(record));
+  await kv.ltrim(SCRAPE_LIST_KEY, 0, 199); // keep latest 200
+}
+
+export async function getRecentScrapeRecords(limit = 20): Promise<ScrapeRecord[]> {
+  if (!isKvConfigured) {
+    return memoryStore.slice(0, limit);
+  }
+  const raw = await kv.lrange<string>(SCRAPE_LIST_KEY, 0, limit - 1);
+  return raw.map((s) => JSON.parse(s) as ScrapeRecord);
+}
+

--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -1,0 +1,51 @@
+import * as cheerio from 'cheerio';
+import { env } from './env';
+import { addScrapeRecord, type ScrapeRecord } from './kv';
+
+export async function runScrapeOnce(): Promise<ScrapeRecord> {
+  if (!env.SCRAPER_TARGET_URL) {
+    throw new Error('SCRAPER_TARGET_URL is not set');
+  }
+
+  const start = Date.now();
+  const res = await fetch(env.SCRAPER_TARGET_URL, {
+    headers: { 'user-agent': 'PersonalToolboxBot/1.0 (+https://vercel.com)' },
+    cache: 'no-store',
+    next: { revalidate: 0 }
+  });
+
+  const html = await res.text();
+  const $ = cheerio.load(html);
+  const text = $('body').text().replace(/\s+/g, ' ').trim().slice(0, 2000);
+
+  const record: ScrapeRecord = {
+    id: String(start),
+    ok: res.ok,
+    url: env.SCRAPER_TARGET_URL,
+    status: res.status,
+    extractedText: text,
+    createdAt: new Date().toISOString()
+  };
+
+  await addScrapeRecord(record);
+
+  if (res.ok && env.WEBHOOK_URL) {
+    try {
+      await fetch(env.WEBHOOK_URL, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          type: 'scrape.success',
+          url: env.SCRAPER_TARGET_URL,
+          status: res.status,
+          createdAt: record.createdAt
+        })
+      });
+    } catch {
+      // ignore webhook errors
+    }
+  }
+
+  return record;
+}
+

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,0 +1,20 @@
+import type { Route } from 'next';
+
+export type Tool = {
+  slug: string;
+  title: string;
+  description: string;
+  href: Route;
+  docsHref?: string;
+};
+
+export const allTools: Tool[] = [
+  {
+    slug: 'scheduled-scraper',
+    title: '定时抓取器 + Webhook 通知',
+    description: '定时抓取网页内容，存储并在页面展示，成功后调用 Webhook 通知',
+    href: '/tools/scraper' as Route,
+    docsHref: 'https://vercel.com/docs/cron-jobs'
+  }
+];
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,46 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": [
+      "dom",
+      "es2020"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": [
+        "./src/components/*"
+      ],
+      "@/lib/*": [
+        "./src/lib/*"
+      ],
+      "@/app/*": [
+        "./src/app/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "src/**/*",
+    "next.config.mjs",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "crons": [
+    {
+      "path": "/api/tools/scraper/run",
+      "schedule": "@hourly"
+    }
+  ]
+}
+


### PR DESCRIPTION
Initialize a Next.js personal toolbox project with a scheduled web scraper and Vercel deployment configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-8670c512-741d-4c9a-8f1c-cb616c2b69bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8670c512-741d-4c9a-8f1c-cb616c2b69bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

