### PR TITLE
Fix cron schedule length error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "crons": [
     {
       "path": "/api/tools/scraper/run",
-      "schedule": "@hourly"
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Update cron schedule to a full 5-field expression to resolve deployment validation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-009ab80c-9cf7-47df-bbea-37c6378189ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-009ab80c-9cf7-47df-bbea-37c6378189ad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

