### PR TITLE
Persist scraped content and fix lark webhook

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "crons": [
     {
       "path": "/api/tools/scraper/run",
-      "schedule": "0 0 * * *"
+      "schedule": "0 1 * * *"
     }
   ]
 }


### PR DESCRIPTION
Update cron schedule for the scraper to run daily at 9 AM Asia/Shanghai.

---
<a href="https://cursor.com/background-agent?bcId=bc-54c2acec-9d15-43d7-86e4-2a7d2105fe54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54c2acec-9d15-43d7-86e4-2a7d2105fe54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

