### PR TITLE
Format scrape success to feishu message

### DIFF
--- a/src/lib/scraper.ts
+++ b/src/lib/scraper.ts
@@ -57,10 +57,9 @@ export async function runScrapeOnce(): Promise<ScrapeRecord> {
 
   if (res.ok && env.WEBHOOK_URL) {
     try {
-      const msg = `抓取成功\nURL: ${env.SCRAPER_TARGET_URL}\n状态: ${res.status}\n时间: ${record.createdAt}`;
       const payload: Record<string, unknown> = {
         msg_type: 'text',
-        content: { text: msg }
+        content: { text: record.extractedText }
       };
       if (env.FEISHU_WEBHOOK_SECRET) {
         const ts = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
Send scraped content directly via webhook instead of a generic "scrape successful" message, formatted for Feishu.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5474104-1721-44ab-b7b3-78f2f25d964f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5474104-1721-44ab-b7b3-78f2f25d964f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

