### PR TITLE
Configure vercel redis for persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@vercel/kv": "^2.0.0",
     "cheerio": "^1.0.0",
+    "ioredis": "5.7.0",
     "next": "^14.2.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -6,7 +6,8 @@ export const env = {
   KV_REST_API_URL: process.env.KV_REST_API_URL ?? '',
   KV_REST_API_TOKEN: process.env.KV_REST_API_TOKEN ?? '',
   KV_REST_API_READ_ONLY_TOKEN: process.env.KV_REST_API_READ_ONLY_TOKEN ?? '',
-  KV_URL: process.env.KV_URL ?? ''
+  KV_URL: process.env.KV_URL ?? '',
+  REDIS_URL: process.env.REDIS_URL ?? ''
 };
 
 export function assertRequiredEnv() {

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -1,6 +1,21 @@
 import { kv } from '@vercel/kv';
+import Redis from 'ioredis';
+import { env } from './env';
 
-const isKvConfigured = Boolean(process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN);
+const isVercelKvConfigured = Boolean(process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN);
+const directRedisUrl = env.REDIS_URL || env.KV_URL;
+
+let redisClient: Redis | null = null;
+
+function getRedisClient(): Redis | null {
+  if (!directRedisUrl) return null;
+  if (redisClient) return redisClient;
+  redisClient = new Redis(directRedisUrl, {
+    maxRetriesPerRequest: 2,
+    enableOfflineQueue: false
+  });
+  return redisClient;
+}
 
 export type ScrapeRecord = {
   id: string;
@@ -15,18 +30,48 @@ const SCRAPE_LATEST_KEY = 'scraper:latest';
 let memoryLatest: ScrapeRecord | null = null;
 
 export async function setLatestScrapeRecord(record: ScrapeRecord): Promise<void> {
-  if (!isKvConfigured) {
-    memoryLatest = record;
+  const payload = JSON.stringify(record);
+
+  // Prefer direct Redis if available
+  const redis = getRedisClient();
+  if (redis) {
+    try {
+      await redis.set(SCRAPE_LATEST_KEY, payload);
+      return;
+    } catch (_) {
+      // fall through to other backends
+    }
+  }
+
+  // Fallback to Vercel KV (REST)
+  if (isVercelKvConfigured) {
+    await kv.set(SCRAPE_LATEST_KEY, payload);
     return;
   }
-  await kv.set(SCRAPE_LATEST_KEY, JSON.stringify(record));
+
+  // Last resort: in-memory (non-persistent)
+  memoryLatest = record;
 }
 
 export async function getLatestScrapeRecord(): Promise<ScrapeRecord | null> {
-  if (!isKvConfigured) {
-    return memoryLatest;
+  // Prefer direct Redis if available
+  const redis = getRedisClient();
+  if (redis) {
+    try {
+      const raw = await redis.get(SCRAPE_LATEST_KEY);
+      return raw ? (JSON.parse(raw) as ScrapeRecord) : null;
+    } catch (_) {
+      // fall through to other backends
+    }
   }
-  const raw = await kv.get<string | null>(SCRAPE_LATEST_KEY);
-  return raw ? (JSON.parse(raw) as ScrapeRecord) : null;
+
+  // Fallback to Vercel KV (REST)
+  if (isVercelKvConfigured) {
+    const raw = await kv.get<string | null>(SCRAPE_LATEST_KEY);
+    return raw ? (JSON.parse(raw) as ScrapeRecord) : null;
+  }
+
+  // Last resort: in-memory (non-persistent)
+  return memoryLatest;
 }
 


### PR DESCRIPTION
Add support for direct Redis connections via `REDIS_URL` or `KV_URL` to enable more flexible persistence options.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e094480-3cf5-408a-a761-f6464b1553ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e094480-3cf5-408a-a761-f6464b1553ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

