### PR TITLE
Debug redis connection issue

### DIFF
--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -7,13 +7,34 @@ const directRedisUrl = env.REDIS_URL || env.KV_URL;
 
 let redisClient: Redis | null = null;
 
+function maskRedisUrl(input: string | undefined): string {
+  if (!input) return '(undefined)';
+  try {
+    const u = new URL(input);
+    // hide username/password, keep host:port and protocol for diagnostics
+    const dbPath = u.pathname && u.pathname !== '/' ? u.pathname : '';
+    return `${u.protocol}//${u.hostname}${u.port ? `:${u.port}` : ''}${dbPath}`;
+  } catch {
+    return '(invalid-url)';
+  }
+}
+
 function getRedisClient(): Redis | null {
-  if (!directRedisUrl) return null;
+  if (!directRedisUrl) {
+    console.log('[kv] redis disabled: missing REDIS_URL/KV_URL');
+    return null;
+  }
   if (redisClient) return redisClient;
+  console.log('[kv] init ioredis', maskRedisUrl(directRedisUrl));
   redisClient = new Redis(directRedisUrl, {
     maxRetriesPerRequest: 2,
     enableOfflineQueue: false
   });
+  redisClient.on('connect', () => console.log('[kv] redis connect', maskRedisUrl(directRedisUrl)));
+  redisClient.on('ready', () => console.log('[kv] redis ready', maskRedisUrl(directRedisUrl)));
+  redisClient.on('end', () => console.log('[kv] redis end', maskRedisUrl(directRedisUrl)));
+  redisClient.on('reconnecting', (delay: number) => console.log('[kv] redis reconnecting in', delay, 'ms'));
+  redisClient.on('error', (e: Error) => console.warn('[kv] redis error', (e as Error).message));
   return redisClient;
 }
 
@@ -36,20 +57,28 @@ export async function setLatestScrapeRecord(record: ScrapeRecord): Promise<void>
   const redis = getRedisClient();
   if (redis) {
     try {
+      const t0 = Date.now();
+      console.log('[kv] set via redis', SCRAPE_LATEST_KEY, 'bytes', payload.length);
       await redis.set(SCRAPE_LATEST_KEY, payload);
+      console.log('[kv] set via redis ok in', Date.now() - t0, 'ms');
       return;
-    } catch (_) {
+    } catch (e) {
+      console.warn('[kv] set via redis failed:', (e as Error).message);
       // fall through to other backends
     }
   }
 
   // Fallback to Vercel KV (REST)
   if (isVercelKvConfigured) {
+    const t0 = Date.now();
+    console.log('[kv] set via vercel-kv', SCRAPE_LATEST_KEY, 'bytes', payload.length);
     await kv.set(SCRAPE_LATEST_KEY, payload);
+    console.log('[kv] set via vercel-kv ok in', Date.now() - t0, 'ms');
     return;
   }
 
   // Last resort: in-memory (non-persistent)
+  console.log('[kv] set via memory fallback (non-persistent)');
   memoryLatest = record;
 }
 
@@ -58,20 +87,28 @@ export async function getLatestScrapeRecord(): Promise<ScrapeRecord | null> {
   const redis = getRedisClient();
   if (redis) {
     try {
+      const t0 = Date.now();
+      console.log('[kv] get via redis', SCRAPE_LATEST_KEY);
       const raw = await redis.get(SCRAPE_LATEST_KEY);
+      console.log('[kv] get via redis', raw ? 'HIT' : 'MISS', 'in', Date.now() - t0, 'ms');
       return raw ? (JSON.parse(raw) as ScrapeRecord) : null;
-    } catch (_) {
+    } catch (e) {
+      console.warn('[kv] get via redis failed:', (e as Error).message);
       // fall through to other backends
     }
   }
 
   // Fallback to Vercel KV (REST)
   if (isVercelKvConfigured) {
+    const t0 = Date.now();
+    console.log('[kv] get via vercel-kv', SCRAPE_LATEST_KEY);
     const raw = await kv.get<string | null>(SCRAPE_LATEST_KEY);
+    console.log('[kv] get via vercel-kv', raw ? 'HIT' : 'MISS', 'in', Date.now() - t0, 'ms');
     return raw ? (JSON.parse(raw) as ScrapeRecord) : null;
   }
 
   // Last resort: in-memory (non-persistent)
+  console.log('[kv] get via memory fallback', memoryLatest ? 'HIT' : 'MISS');
   return memoryLatest;
 }
 


### PR DESCRIPTION
Add detailed debug logging to KV store operations (Redis, Vercel KV, memory) to diagnose issues with `getLatestScrapeRecord` returning null.

The user reported that `getLatestScrapeRecord` consistently returned `null` even when `REDIS_URL` was configured. This PR introduces comprehensive logging around Redis initialization, connection events, and `set`/`get` operations, as well as for Vercel KV and in-memory fallbacks, to pinpoint whether the problem lies in Redis connectivity, write failures, read misses, or if a fallback store is being used unexpectedly.

---
<a href="https://cursor.com/background-agent?bcId=bc-290fe093-a15e-429e-9a65-b4a7d0337295">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-290fe093-a15e-429e-9a65-b4a7d0337295">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

