### PR TITLE
Fix redis stream write error

### DIFF
--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -28,7 +28,7 @@ function getRedisClient(): Redis | null {
   console.log('[kv] init ioredis', maskRedisUrl(directRedisUrl));
   redisClient = new Redis(directRedisUrl, {
     maxRetriesPerRequest: 2,
-    enableOfflineQueue: false
+    enableOfflineQueue: true
   });
   redisClient.on('connect', () => console.log('[kv] redis connect', maskRedisUrl(directRedisUrl)));
   redisClient.on('ready', () => console.log('[kv] redis ready', maskRedisUrl(directRedisUrl)));


### PR DESCRIPTION
Enable Redis offline queue to prevent "Stream isn't writeable" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb349046-d0fe-40e2-9aad-d4f214188b8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb349046-d0fe-40e2-9aad-d4f214188b8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

