### PR TITLE
Ensure redis connection on startup

### DIFF
--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -5,7 +5,37 @@ import { env } from './env';
 const isVercelKvConfigured = Boolean(process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN);
 const directRedisUrl = env.REDIS_URL || env.KV_URL;
 
-let redisClient: Redis | null = null;
+let redisClient: any | null = null;
+
+async function waitForRedisReady(client: any, timeoutMs = 5000): Promise<void> {
+  if (client.status === 'ready') return;
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('redis ready timeout'));
+    }, timeoutMs);
+    const onReady = () => {
+      cleanup();
+      resolve();
+    };
+    const onEnd = (err?: unknown) => {
+      cleanup();
+      reject(new Error('redis ended before ready'));
+    };
+    const onError = (e: Error) => {
+      // keep waiting; only reject on timeout/end
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      client.off('ready', onReady);
+      client.off('end', onEnd);
+      client.off('error', onError as any);
+    };
+    client.once('ready', onReady);
+    client.once('end', onEnd);
+    client.on('error', onError as any);
+  });
+}
 
 function maskRedisUrl(input: string | undefined): string {
   if (!input) return '(undefined)';
@@ -19,7 +49,7 @@ function maskRedisUrl(input: string | undefined): string {
   }
 }
 
-function getRedisClient(): Redis | null {
+function getRedisClient(): any | null {
   if (!directRedisUrl) {
     console.log('[kv] redis disabled: missing REDIS_URL/KV_URL');
     return null;
@@ -36,6 +66,17 @@ function getRedisClient(): Redis | null {
   redisClient.on('reconnecting', (delay: number) => console.log('[kv] redis reconnecting in', delay, 'ms'));
   redisClient.on('error', (e: Error) => console.warn('[kv] redis error', (e as Error).message));
   return redisClient;
+}
+
+// Eagerly initialize on module load so the app connects at startup
+if (directRedisUrl) {
+  try {
+    const client = getRedisClient();
+    // fire and forget readiness wait for logging; do not block module load
+    if (client) {
+      waitForRedisReady(client, 8000).catch(() => {});
+    }
+  } catch {}
 }
 
 export type ScrapeRecord = {
@@ -57,6 +98,7 @@ export async function setLatestScrapeRecord(record: ScrapeRecord): Promise<void>
   const redis = getRedisClient();
   if (redis) {
     try {
+      await waitForRedisReady(redis, 4000);
       const t0 = Date.now();
       console.log('[kv] set via redis', SCRAPE_LATEST_KEY, 'bytes', payload.length);
       await redis.set(SCRAPE_LATEST_KEY, payload);
@@ -87,6 +129,7 @@ export async function getLatestScrapeRecord(): Promise<ScrapeRecord | null> {
   const redis = getRedisClient();
   if (redis) {
     try {
+      await waitForRedisReady(redis, 4000);
       const t0 = Date.now();
       console.log('[kv] get via redis', SCRAPE_LATEST_KEY);
       const raw = await redis.get(SCRAPE_LATEST_KEY);

--- a/src/types/ioredis.d.ts
+++ b/src/types/ioredis.d.ts
@@ -1,0 +1,2 @@
+declare module 'ioredis';
+


### PR DESCRIPTION
Eagerly connect Redis at startup and gate KV operations to avoid "Stream isn't writeable" errors.

The previous implementation allowed `ioredis` commands to be sent before the client was fully connected and ready, leading to errors when `enableOfflineQueue` was not active. This change ensures that `get` and `set` operations wait for Redis to be ready (with a timeout) or fall back gracefully.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca6128e1-0609-43a6-b6f5-c6dfc66f7238">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca6128e1-0609-43a6-b6f5-c6dfc66f7238">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

